### PR TITLE
Hotfix/1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ swagger-ui available at http://localhost:8082/webjars/swagger-ui/index.html
 cd back/api-gateway
 ./mvnw spring-boot:run
 ```
+swagger-ui available at http://localhost:8080/api/swagger-ui.html
 
 ```bash
 cd front
@@ -161,3 +162,5 @@ Open a terminal in the **resources/compose/mdd** folder and run:
 docker-compose up -d
 ```
 The application will be accessible from http://localhost
+
+And swagger ui from http://localhost/api/swagger-ui.html

--- a/resources/compose/mdd/props/api-gateway-application.yml
+++ b/resources/compose/mdd/props/api-gateway-application.yml
@@ -65,16 +65,18 @@ spring:
         - Path=/api/auth/**
   main:
     web-application-type: reactive
+
 springdoc:
   enable-native-support: true
   api-docs:
     enabled: true
+    path: /api/v3/api-docs
   swagger-ui:
     enabled: true
     path: /api/swagger-ui.html
-    config-url: /v3/api-docs/swagger-config
+    config-url: /api/v3/api-docs/swagger-config
     urls:
-      - url: /v3/api-docs
+      - url: /api/v3/api-docs
         name: API Gateway
         primaryName: API Gateway Service
       - url: /api/posts/v3/api-docs
@@ -92,6 +94,7 @@ springdoc:
       - url: /api/users/v3/api-docs
         name: Users API
         primaryName: Users API
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
FIX default swagger sample page shown instead of API's
Swagger config path was intercepted by nginx proxy